### PR TITLE
Fix `\author`, `\major`, `\supervisor` bug.

### DIFF
--- a/hustthesis/hustthesis.dtx
+++ b/hustthesis/hustthesis.dtx
@@ -2504,14 +2504,14 @@
 %<example-zh>\title{\LaTeX 模板使用示例}{An Example of Using hustthesis \LaTeX{} Template}
 %<example-en>\title{An Example of Using hustthesis \LaTeX{} Template}
 \author
-%<example-zh>{许铖}
-{Xu Cheng}
+%<example-zh>{许铖}{Xu Cheng}
+%<example-en>{}
 \major
-%<example-zh>{电子信息工程}
-{Electronic and Information Engineering}
+%<example-zh>{电子信息工程}{Electronic and Information Engineering}
+%<example-en>{}
 \supervisor
-%<example-zh>{黑晓军\hspace{1em}副教授}
-{Ass. Prof. Xiaojun Hei}
+%<example-zh>{黑晓军\hspace{1em}副教授}{Ass. Prof. Xiaojun Hei}
+%<example-en>{}
 \date{2013}{7}{1}
 
 %<*example-zh>


### PR DESCRIPTION
Since compile failed both in zh and en example using xelatex.

My usage:

```
makewin32.bat unpack
cd hustthesis
xelatex hustthesis-zh-example
```

hustthesis-zh-example.log:

> This is XeTeX, Version 3.14159265-2.6-0.99992 (TeX Live 2015/W32TeX) (preloaded
format=xelatex)
 restricted \write18 enabled.
entering extended mode
(./hustthesis-zh-example.tex
LaTeX2e <2015/01/01>
Babel <3.9l> and hyphenation patterns for 79 languages loaded.
(./hustthesis.cls
Document Class: hustthesis 2013/07/01 v1.1 A Thesis Template for Huazhong Unive
rsity of Science and Technology

...

> ! LaTeX Error: Missing \begin{document}.
See the LaTeX manual or LaTeX Companion for explanation.
Type  H <return>  for immediate help.
 ...
l.52 {X
       u Cheng}