### PR TITLE
change header to double line

### DIFF
--- a/hustthesis/hustthesis.dtx
+++ b/hustthesis/hustthesis.dtx
@@ -2083,7 +2083,7 @@
       \vskip -5pt
       \vbox{
         \hrule width \textwidth height 0.5pt \vskip 1pt
-         \hrule width \textwidth height 0.5pt
+        \hrule width \textwidth height 0.5pt
       }
     }
   \fi

--- a/hustthesis/hustthesis.dtx
+++ b/hustthesis/hustthesis.dtx
@@ -2082,7 +2082,8 @@
       \ziju{1em}{\kai{\fontsize{14pt}{18.2pt}\selectfont\HUST@zhschoolname\HUST@zhapplyname}}
       \vskip -5pt
       \vbox{
-        \hrule width \textwidth height 2pt
+        \hrule width \textwidth height 0.5pt \vskip 1pt
+         \hrule width \textwidth height 0.5pt
       }
     }
   \fi


### PR DESCRIPTION
In readme we stated to use double line for header but actually it's single line, this pr adds the correct double lines to \fancyhead