### PR TITLE
修正博士论文英文封面翻译问题

### DIFF
--- a/hustthesis/hustthesis.dtx
+++ b/hustthesis/hustthesis.dtx
@@ -368,7 +368,7 @@
 %     \verb+fyp+ & 毕业论文 & A Thesis Submitted in Partial Fulfillment of the Requirements for Final Year Project \\ \hline
 %     \verb+bachelor+ & 学士学位论文 & A Thesis Submitted in Partial Fulfillment of the Requirements for the Degree of Bachelor \\ \hline
 %     \verb+master+ & 硕士学位论文 & A Thesis Submitted in Partial Fulfillment of the Requirements for the Degree of Master \\ \hline
-%     \verb+phd+ & 博士学位论文 & A Thesis Submitted in Partial Fulfillment of the Requirements for the Degree of Philosophy \\ \hline
+%     \verb+phd+ & 博士学位论文 & A Thesis Submitted in Partial Fulfillment of the Requirements for the Degree of Doctor of Philosophy \\ \hline
 %     \end{tabularx}
 % \end{table}
 %
@@ -803,7 +803,7 @@
 %     \verb+fyp+ & A Thesis Submitted in Partial Fulfillment of the Requirements for Final Year Project \\ \hline
 %     \verb+bachelor+ & A Thesis Submitted in Partial Fulfillment of the Requirements for the Degree of Bachelor \\ \hline
 %     \verb+master+ & A Thesis Submitted in Partial Fulfillment of the Requirements for the Degree of Master \\ \hline
-%     \verb+phd+ & A Thesis Submitted in Partial Fulfillment of the Requirements for the Degree of Philosophy \\ \hline
+%     \verb+phd+ & A Thesis Submitted in Partial Fulfillment of the Requirements for the Degree of Doctor of Philosophy \\ \hline
 %     \end{tabularx}
 % \end{table}
 %
@@ -1772,7 +1772,7 @@
 
 \ifthenelse{\equal{\HUST@degree}{phd}}{
   \def\HUST@zhapplyname{博士学位论文}
-  \def\HUST@enapplyname{A Thesis Submitted in Partial Fulfillment of the Requirements for the Degree of Philosophy}
+  \def\HUST@enapplyname{A Thesis Submitted in Partial Fulfillment of the Requirements for the Degree of Doctor of Philosophy}
 }{}
 
 \ifthenelse{\equal{\HUST@language}{chinese}}{


### PR DESCRIPTION
修正翻译，重新开PR。

不过按照惯例，英文封面似乎应当注明“Doctor of Philosophy in Engineering”或其他相应学科